### PR TITLE
fixed a bug with writeToTableInChunks

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -533,14 +533,20 @@ module.exports = function (configuration) {
 					let hash = opts.keys[0];
 					let range = opts.keys[1];
 
-					let seen = {};
+					let seen = new Set();
 					// Process in reverse, so that the newest record goes through and so I can delete without readjusting keys
 					for (let i = items.length - 1; i >= 0; i--) {
-						let id = items[i].PutRequest.Item[hash] + '' + items[i].PutRequest.Item[range];
-						if (id in seen) {
+						let id;
+						if (items[i].PutRequest) {
+							id = items[i].PutRequest.Item[hash] + '' + items[i].PutRequest.Item[range];
+						}
+						else {
+							id = items[i].DeleteRequest.Key[hash] + '' + items[i].DeleteRequest.Key[range];
+						}
+						if (seen.has(id)) {
 							items.splice(i, 1);
 						} else {
-							seen[id] = 1;
+							seen.add(id);
 						}
 					}
 				}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "leo-aws",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Helper wrappers around AWS services, specifically to ease backoff retry and streaming of data into and out of AWS services",
 	"main": "index.js",
 	"directories": {


### PR DESCRIPTION
The function allows deletes and put's to be intermingled, but then wasn't recognizing when iterating through items that some of them might be deletes (and therefore wouldn't have a PutRequest or an Item to de-reference)